### PR TITLE
Link player names to first-region view on leaderboard

### DIFF
--- a/root/player/all_home.tt
+++ b/root/player/all_home.tt
@@ -29,7 +29,7 @@ Picks
    <span class="cash">
    [% i == 2 ? '$' _ c.config.prizes.first_place : i == 3 ? '$' _ c.config.prizes.second_place  : i == 4 ? '$' _ c.config.prizes.third_place : '' %]
    </span>
-   <a class="player-link" href="[% c.uri_for('/region/view/1/') _ player.id %]">[% player.first_name | ucfirst %] [% player.last_name | ucfirst %]</a>
+   <a class="player-link" style="color:black;text-decoration:none;" href="[% c.uri_for('/region/view/1/') _ player.id %]">[% player.first_name | ucfirst %] [% player.last_name | ucfirst %]</a>
    </td>
    <td style="text-align:center;">&nbsp;<span class="points">[% player.points %]&nbsp;</span> </td>
    <td style="font-size:0.92em;" class="secondary">

--- a/root/static/css/main.css
+++ b/root/static/css/main.css
@@ -99,8 +99,8 @@ table#all_player_home {
 #all_player_home a.player-link:hover,
 #all_player_home a.player-link:active,
 #all_player_home a.player-link:focus {
-	color: black;
-	text-decoration: none;
+	color: black !important;
+	text-decoration: none !important;
 }
 
 /* Styles Regional Bracke */


### PR DESCRIPTION
## Summary
- link player names in `/all` leaderboard to `/region/view/1/<player_id>`
- style links to appear like plain text (black, no underline)
- add stronger fallback styling for cross-browser consistency

## Testing
- restarted `bracket3030.service`
- verified app is healthy (`/all` redirects to `/login` when unauthenticated)
