### PR TITLE
refactor: remove jQuery dependency from picks frontend JS

### DIFF
--- a/root/lib/site/html.tt
+++ b/root/lib/site/html.tt
@@ -7,7 +7,6 @@
 <meta name="viewport" content="initial-scale=1.0, width=device-width" />
 [% site_title = c.config.name _ " " _ c.config.year %]
 <title>[% page_head_title or page_title or template.title %] : [% site_title %]</title>
-<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
 [%- INCLUDE lib/site/javascripts.tt -%]
 [%- INCLUDE lib/site/style_sheets.tt -%]
 </head>

--- a/root/static/javascript/bracket_picks.js
+++ b/root/static/javascript/bracket_picks.js
@@ -1,53 +1,57 @@
-// code to execute when the DOM is ready
-$(document).ready(function(){
+document.addEventListener('DOMContentLoaded', function () {
+  var pattern = /r(\d+)-t(\d+)-rg(\d+)/;
 
-    var pattern = /r(\d+)-t(\d+)-rg(\d+)/;
-   	pattern_array = new Array();
-    
-    //if ( $('form.regional_bracket') ) {
-    	$('p').click(function(e){  
-         	var span_id = $(this).find('span').attr('id');
-         	pattern_array = span_id.match(pattern);
-         	var round = parseInt(pattern_array[1]) + 1;
-         	var team = pattern_array[2];
-    		var region = pattern_array[3];
-         	var new_id = 'r' + round + '-t' + team + '-rg' + region;
-    		var game = advance_team(team, round, region);
-    		var pick_game = 'p' + game;
-    		var pick_string = '<span id="' + new_id + '">' + '<input type="hidden" name="' + pick_game + '" value="' + team + '" /></span>';
-    		next_game = '#w' + game;
-    		$(next_game).html($(this).text() + pick_string);    
-    	}); 
-  //  }
+  document.querySelectorAll('p').forEach(function (p) {
+    p.addEventListener('click', function () {
+      var span = p.querySelector('span');
+      if (!span) return;
+
+      var spanId = span.getAttribute('id') || '';
+      var patternArray = spanId.match(pattern);
+      if (!patternArray) return;
+
+      var round = parseInt(patternArray[1], 10) + 1;
+      var team = patternArray[2];
+      var region = patternArray[3];
+      var newId = 'r' + round + '-t' + team + '-rg' + region;
+      var game = advance_team(parseInt(team, 10), round, parseInt(region, 10));
+      var pickGame = 'p' + game;
+
+      var nextGame = document.querySelector('#w' + game);
+      if (!nextGame) return;
+
+      nextGame.innerHTML =
+        p.textContent +
+        '<span id="' +
+        newId +
+        '"><input type="hidden" name="' +
+        pickGame +
+        '" value="' +
+        team +
+        '" /></span>';
+    });
+  });
 });
 
-	
-function advance_team(team, round, region) {	
-
-	var region_addend = 15*(region - 1);
-	var round_addend;
-	if (round == 0) {
-		round_addend = 0;
-	}
-	else if (round == 1) {
-		round_addend = 0;
-	}
-	else if (round == 2) {
-		round_addend = 8;
-	}
-	else if (round == 3) {
-		round_addend = 12;
-	}
-	else if (round == 4) {
-		round_addend = 14;
-	}
-	var divisor = Math.pow(2,round);
-	var team_addend = parseInt( (team-( 16*(region-1 ))) / divisor);
-	var result = team_addend + round_addend + region_addend;
-	if (team % divisor != 0) {
-		result += 1;
-	}	
-	//alert('round addend: ' + round_addend + ' team addend: ' + team_addend + ' region addend: ' + region_addend + ' result ' + result + ' divisor: ' + divisor  + ' round: ' + round );
-	//alert(result);
-	return result;
+function advance_team(team, round, region) {
+  var region_addend = 15 * (region - 1);
+  var round_addend;
+  if (round == 0) {
+    round_addend = 0;
+  } else if (round == 1) {
+    round_addend = 0;
+  } else if (round == 2) {
+    round_addend = 8;
+  } else if (round == 3) {
+    round_addend = 12;
+  } else if (round == 4) {
+    round_addend = 14;
+  }
+  var divisor = Math.pow(2, round);
+  var team_addend = parseInt((team - 16 * (region - 1)) / divisor, 10);
+  var result = team_addend + round_addend + region_addend;
+  if (team % divisor != 0) {
+    result += 1;
+  }
+  return result;
 }

--- a/root/static/javascript/final4_picks.js
+++ b/root/static/javascript/final4_picks.js
@@ -1,23 +1,43 @@
-// code to execute when the DOM is ready
-$(document).ready(function(){
+document.addEventListener('DOMContentLoaded', function () {
+  var pattern = /w(\d+)-t(\d+)/;
 
-    var pattern = /w(\d+)-t(\d+)/;
-   	pattern_array = new Array();
-    
-	$('p').click(function(e){  
-     	var span_id = $(this).find('span').attr('id');
-     	pattern_array = span_id.match(pattern);
-     	var game_number = parseInt(pattern_array[1]);
-     	var team = pattern_array[2];
-     	var next_game_number;
-     	if (game_number == 15 || game_number == 30) { next_game_number = 61 }
-     	else if (game_number == 45 || game_number == 60) { next_game_number = 62 }
-     	else if (game_number == 61 || game_number == 62) { next_game_number = 63 }
-     	var new_id = 'w' + next_game_number + '-t' + team ;
-		var game = next_game_number;
-		var pick_game = 'p' + game;
-		var pick_string = '<span id="' + new_id + '">' + '<input type="hidden" name="' + pick_game + '" value="' + team + '" /></span>';
-		next_game = '#w' + game;
-		$(next_game).html($(this).text() + pick_string);    
-	}); 
+  document.querySelectorAll('p').forEach(function (p) {
+    p.addEventListener('click', function () {
+      var span = p.querySelector('span');
+      if (!span) return;
+
+      var spanId = span.getAttribute('id') || '';
+      var patternArray = spanId.match(pattern);
+      if (!patternArray) return;
+
+      var gameNumber = parseInt(patternArray[1], 10);
+      var team = patternArray[2];
+      var nextGameNumber;
+
+      if (gameNumber == 15 || gameNumber == 30) {
+        nextGameNumber = 61;
+      } else if (gameNumber == 45 || gameNumber == 60) {
+        nextGameNumber = 62;
+      } else if (gameNumber == 61 || gameNumber == 62) {
+        nextGameNumber = 63;
+      } else {
+        return;
+      }
+
+      var newId = 'w' + nextGameNumber + '-t' + team;
+      var pickGame = 'p' + nextGameNumber;
+      var nextGame = document.querySelector('#w' + nextGameNumber);
+      if (!nextGame) return;
+
+      nextGame.innerHTML =
+        p.textContent +
+        '<span id="' +
+        newId +
+        '"><input type="hidden" name="' +
+        pickGame +
+        '" value="' +
+        team +
+        '" /></span>';
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- remove jQuery dependency from picks frontend flow
- refactor to vanilla DOM/event handling in:
  - `root/lib/site/html.tt`
  - `root/static/javascript/bracket_picks.js`
  - `root/static/javascript/final4_picks.js`

## Validation
- fam-browser real-browser run against `https://bracket.mso.mt/`
- completed/saved all 4 regions first, then Final4 click-flow
- verified `w61/w62/w63` propagation and save+reload persistence
- no console/page errors observed
