### PR TITLE
Expand Perl CI test coverage

### DIFF
--- a/.github/workflows/perl-tests.yml
+++ b/.github/workflows/perl-tests.yml
@@ -74,9 +74,12 @@ jobs:
             t/continuity_audit.t \
             t/controller_Admin.t \
             t/controller_Auth.t \
+            t/controller_Auth_email_link.t \
             t/controller_Region.t \
             t/deploy_bracket_mysql_postdeploy.t \
+            t/edit_cutoff_time.t \
             t/equity_projection.t \
+            t/model_round_based_final4_counts.t \
             t/model_update_points.t \
             t/pick_saver.t \
             t/player_all_sorting.t \


### PR DESCRIPTION
## Summary
- add three existing regression tests to the GitHub Perl workflow
- keep POD/POD-coverage tests out of the default CI run for now
- broaden packaged-stack coverage without changing CI scope dramatically

## Testing
- script/test-env.sh prove -Ilib -It/lib -lv t/controller_Auth_email_link.t t/edit_cutoff_time.t t/model_round_based_final4_counts.t