### PR TITLE
feat: cache default equity projection for leaderboard

### DIFF
--- a/lib/Bracket/Controller/Admin.pm
+++ b/lib/Bracket/Controller/Admin.pm
@@ -260,8 +260,16 @@ sub equity_report : Global {
     $seed = 1        if $seed < 1;
     $seed = MAX_SEED if $seed > MAX_SEED;
 
-    my $projection = Bracket::Service::EquityProjection->project(
-        $c->model('DBIC')->schema,
+    my $schema = $c->model('DBIC')->schema;
+    my $use_cached_default = $iterations == Bracket::Service::EquityProjection::DEFAULT_ITERATIONS()
+      && $seed == Bracket::Service::EquityProjection::DEFAULT_SEED();
+
+    my $projection = $use_cached_default
+      ? Bracket::Service::EquityProjection->load_default_cache($schema)
+      : undef;
+
+    $projection ||= Bracket::Service::EquityProjection->project(
+        $schema,
         {
             iterations => $iterations,
             seed       => $seed,

--- a/lib/Bracket/Controller/Player.pm
+++ b/lib/Bracket/Controller/Player.pm
@@ -127,7 +127,9 @@ sub all : Global {
       $projection_metrics->{act_by_player} = $c->stash->{teams_left_per_player} || {};
       $projection_metrics->{fi4_by_player} = $c->stash->{final4_teams_left_per_player} || {};
 
-      my $projection = Bracket::Service::EquityProjection->project(
+      my $projection = Bracket::Service::EquityProjection->load_default_cache(
+          $c->model('DBIC')->schema
+      ) || Bracket::Service::EquityProjection->project(
           $c->model('DBIC')->schema,
           {
               iterations => 2000,

--- a/lib/Bracket/Model/DBIC.pm
+++ b/lib/Bracket/Model/DBIC.pm
@@ -38,8 +38,11 @@ sub _update_points_for_schema {
       ? _update_points_mysql($schema)
       : _update_points_portable($schema);
 
+    my $cache_started = time();
     Bracket::Service::EquityProjection->refresh_default_cache($schema);
-    return $stats;
+    my $cache_elapsed = time() - $cache_started;
+
+    return _append_update_stat($stats, equity_cache => $cache_elapsed);
 }
 
 sub _update_points_mysql {
@@ -308,6 +311,19 @@ sub _format_update_stats {
     } sort { ($times->{$b} // 0) <=> ($times->{$a} // 0) } keys %{$times};
     unshift(@stats, "<u>total time: $total_time</u>");
     return join('<br>', @stats);
+}
+
+sub _append_update_stat {
+    my ($stats, $label, $seconds) = @_;
+    $stats ||= _format_update_stats({});
+    $seconds ||= 0;
+
+    my $new_ms = sprintf('%.1f', 1000 * $seconds);
+    if ($stats =~ s{<u>total time: ([0-9.]+)</u>}{'<u>total time: ' . sprintf('%.1f', $1 + $new_ms) . '</u>'}e) {
+        return $stats . '<br>' . $label . ': ' . $new_ms;
+    }
+
+    return $stats . '<br>' . $label . ': ' . $new_ms;
 }
 
 =heads2 count_region_picks

--- a/lib/Bracket/Model/DBIC.pm
+++ b/lib/Bracket/Model/DBIC.pm
@@ -34,9 +34,12 @@ sub update_points {
 sub _update_points_for_schema {
     my ($schema) = @_;
     my $driver = lc($schema->storage->dbh->{Driver}->{Name} || '');
-    return $driver eq 'mysql'
+    my $stats = $driver eq 'mysql'
       ? _update_points_mysql($schema)
       : _update_points_portable($schema);
+
+    Bracket::Service::EquityProjection->refresh_default_cache($schema);
+    return $stats;
 }
 
 sub _update_points_mysql {
@@ -292,10 +295,6 @@ sub _update_points_portable {
     });
     $current_time = time();
     $times{update_player_points} = $current_time - $previous_time;
-
-    Bracket::Service::EquityProjection->refresh_default_cache($schema);
-    $current_time = time();
-    $times{equity_cache} = $current_time - $previous_time;
 
     return _format_update_stats(\%times);
 }

--- a/lib/Bracket/Model/DBIC.pm
+++ b/lib/Bracket/Model/DBIC.pm
@@ -5,6 +5,7 @@ use base 'Catalyst::Model::DBIC::Schema';
 use List::Util qw( first max sum );
 use Time::HiRes qw/ time /;
 use Bracket::Service::BracketStructure;
+use Bracket::Service::EquityProjection;
 
 __PACKAGE__->config(schema_class => 'Bracket::Schema',);
 
@@ -291,6 +292,10 @@ sub _update_points_portable {
     });
     $current_time = time();
     $times{update_player_points} = $current_time - $previous_time;
+
+    Bracket::Service::EquityProjection->refresh_default_cache($schema);
+    $current_time = time();
+    $times{equity_cache} = $current_time - $previous_time;
 
     return _format_update_stats(\%times);
 }

--- a/lib/Bracket/Schema/Result/EquityCache.pm
+++ b/lib/Bracket/Schema/Result/EquityCache.pm
@@ -1,0 +1,84 @@
+package Bracket::Schema::Result::EquityCache;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 NAME
+
+Bracket::Schema::Result::EquityCache - Per-player default equity projection cache
+
+=cut
+
+__PACKAGE__->table("equity_cache");
+
+=head1 ACCESSORS
+
+=head2 player_id
+
+  data_type: INT
+  is_nullable: 0
+
+=head2 cache_key
+
+  data_type: VARCHAR
+  size: 32
+  is_nullable: 0
+  default: 'default'
+
+=head2 current_points
+
+  data_type: INT
+  is_nullable: 0
+  default: 0
+
+=head2 max_possible_points
+
+  data_type: INT
+  is_nullable: 0
+  default: 0
+
+=head2 projected_first_pct
+
+  data_type: VARCHAR
+  size: 16
+  is_nullable: 0
+  default: '0.00'
+
+=head2 projected_podium_pct
+
+  data_type: VARCHAR
+  size: 16
+  is_nullable: 0
+  default: '0.00'
+
+=head2 projected_score_avg
+
+  data_type: VARCHAR
+  size: 16
+  is_nullable: 0
+  default: '0.00'
+
+=cut
+
+__PACKAGE__->add_columns(
+    "player_id",
+    { data_type => "INT", is_nullable => 0 },
+    "cache_key",
+    { data_type => "VARCHAR", size => 32, is_nullable => 0, default_value => 'default' },
+    "current_points",
+    { data_type => "INT", is_nullable => 0, default_value => 0 },
+    "max_possible_points",
+    { data_type => "INT", is_nullable => 0, default_value => 0 },
+    "projected_first_pct",
+    { data_type => "VARCHAR", size => 16, is_nullable => 0, default_value => '0.00' },
+    "projected_podium_pct",
+    { data_type => "VARCHAR", size => 16, is_nullable => 0, default_value => '0.00' },
+    "projected_score_avg",
+    { data_type => "VARCHAR", size => 16, is_nullable => 0, default_value => '0.00' },
+);
+
+__PACKAGE__->set_primary_key("player_id", "cache_key");
+
+1;

--- a/lib/Bracket/Service/EquityProjection.pm
+++ b/lib/Bracket/Service/EquityProjection.pm
@@ -528,6 +528,8 @@ sub refresh_default_cache {
     my ($class, $schema) = @_;
     return if !$schema;
 
+    _ensure_cache_table($schema);
+
     my $projection = $class->project($schema, {
         iterations => DEFAULT_ITERATIONS,
         seed       => DEFAULT_SEED,
@@ -565,6 +567,8 @@ sub load_default_cache {
     my ($class, $schema) = @_;
     return undef if !$schema;
 
+    _ensure_cache_table($schema);
+
     my @rows = $schema->resultset('EquityCache')
         ->search({ cache_key => DEFAULT_CACHE_KEY })
         ->all;
@@ -582,6 +586,54 @@ sub load_default_cache {
     } @rows;
 
     return { player_projections => \@player_projections };
+}
+
+sub _ensure_cache_table {
+    my ($schema) = @_;
+    return if !$schema;
+
+    my $storage = $schema->storage;
+    my $dbh = $storage->dbh;
+    my $driver = lc($dbh->{Driver}{Name} || '');
+
+    if ($driver eq 'mysql') {
+        $dbh->do(q{
+            create table if not exists equity_cache (
+                player_id int not null,
+                cache_key varchar(32) not null default 'default',
+                current_points int not null default 0,
+                max_possible_points int not null default 0,
+                projected_first_pct varchar(16) not null default '0.00',
+                projected_podium_pct varchar(16) not null default '0.00',
+                projected_score_avg varchar(16) not null default '0.00',
+                primary key (player_id, cache_key)
+            )
+        });
+        return;
+    }
+
+    if ($driver eq 'sqlite') {
+        $dbh->do(q{
+            create table if not exists equity_cache (
+                player_id integer not null,
+                cache_key varchar(32) not null default 'default',
+                current_points integer not null default 0,
+                max_possible_points integer not null default 0,
+                projected_first_pct varchar(16) not null default '0.00',
+                projected_podium_pct varchar(16) not null default '0.00',
+                projected_score_avg varchar(16) not null default '0.00',
+                primary key (player_id, cache_key)
+            )
+        });
+        return;
+    }
+
+    my $table = eval { $schema->storage->dbh->selectrow_arrayref(q{
+        select 1 from equity_cache where 1 = 0
+    }) };
+    return if $table || !$@;
+
+    die 'equity_cache table is missing and automatic creation is only implemented for MySQL/SQLite';
 }
 
 1;

--- a/lib/Bracket/Service/EquityProjection.pm
+++ b/lib/Bracket/Service/EquityProjection.pm
@@ -510,4 +510,78 @@ sub _dedupe {
     return grep { defined $_ && !$seen{$_}++ } @values;
 }
 
+use constant DEFAULT_CACHE_KEY  => 'default';
+use constant DEFAULT_ITERATIONS => 2000;
+use constant DEFAULT_SEED       => 17;
+
+=head2 refresh_default_cache
+
+    Bracket::Service::EquityProjection->refresh_default_cache($schema);
+
+Runs the default equity projection (iterations=2000, seed=17) and stores the
+per-player results in the C<equity_cache> table under cache_key C<'default'>.
+Any previous rows for that cache_key are replaced atomically.
+
+=cut
+
+sub refresh_default_cache {
+    my ($class, $schema) = @_;
+    return if !$schema;
+
+    my $projection = $class->project($schema, {
+        iterations => DEFAULT_ITERATIONS,
+        seed       => DEFAULT_SEED,
+    });
+
+    $schema->txn_do(sub {
+        $schema->resultset('EquityCache')->search({ cache_key => DEFAULT_CACHE_KEY })->delete;
+        for my $row (@{$projection->{player_projections} || []}) {
+            next if !$row->{player_id};
+            $schema->resultset('EquityCache')->create({
+                player_id            => $row->{player_id},
+                cache_key            => DEFAULT_CACHE_KEY,
+                current_points       => $row->{current_points}       // 0,
+                max_possible_points  => $row->{max_possible_points}  // 0,
+                projected_first_pct  => $row->{projected_first_pct}  // '0.00',
+                projected_podium_pct => $row->{projected_podium_pct} // '0.00',
+                projected_score_avg  => $row->{projected_score_avg}  // '0.00',
+            });
+        }
+    });
+    return;
+}
+
+=head2 load_default_cache
+
+    my $projection = Bracket::Service::EquityProjection->load_default_cache($schema);
+
+Loads the cached default equity projection from the database.  Returns a
+hashref with a C<player_projections> key in the same format as C<project()>,
+or C<undef> if the cache is empty.
+
+=cut
+
+sub load_default_cache {
+    my ($class, $schema) = @_;
+    return undef if !$schema;
+
+    my @rows = $schema->resultset('EquityCache')
+        ->search({ cache_key => DEFAULT_CACHE_KEY })
+        ->all;
+    return undef if !@rows;
+
+    my @player_projections = map {
+        {
+            player_id            => $_->get_column('player_id'),
+            current_points       => $_->get_column('current_points'),
+            max_possible_points  => $_->get_column('max_possible_points'),
+            projected_first_pct  => $_->get_column('projected_first_pct'),
+            projected_podium_pct => $_->get_column('projected_podium_pct'),
+            projected_score_avg  => $_->get_column('projected_score_avg'),
+        }
+    } @rows;
+
+    return { player_projections => \@player_projections };
+}
+
 1;

--- a/t/controller_Admin.t
+++ b/t/controller_Admin.t
@@ -14,9 +14,35 @@ use Bracket::Service::BracketStructure;
 }
 
 {
+    package TestRequest;
+    sub new { my ($class, $params) = @_; return bless { params => $params || {} }, $class; }
+    sub params { return $_[0]->{params}; }
+}
+
+{
+    package TestResponse;
+    sub new { return bless { redirect_to => undef }, shift; }
+    sub redirect { my ($self, $to) = @_; $self->{redirect_to} = $to; return; }
+    sub redirect_to { return $_[0]->{redirect_to}; }
+}
+
+{
+    package TestAction;
+    sub new { my ($class, $name) = @_; return bless { name => $name }, $class; }
+    sub name { return $_[0]->{name}; }
+}
+
+{
+    package TestControllerRef;
+    sub new { my ($class, $name) = @_; return bless { name => $name }, $class; }
+    sub action_for { my ($self, $name) = @_; return TestAction->new($name); }
+}
+
+{
     package TestDBICModel;
-    sub new { my ($class, $schema) = @_; return bless { schema => $schema }, $class; }
+    sub new { my ($class, $schema) = @_; return bless { schema => $schema, update_points_result => '<u>total time: 1.0</u><br>equity_cache: 0.5' }, $class; }
     sub schema { return $_[0]->{schema}; }
+    sub update_points { return $_[0]->{update_points_result}; }
     sub count_player_picks {
         my ($self) = @_;
         my %counts;
@@ -72,10 +98,13 @@ use Bracket::Service::BracketStructure;
         my ($class, $schema, $roles) = @_;
         return bless {
             stash => {},
+            flash => {},
             go_to => undef,
             dbic  => TestDBICModel->new($schema),
             schema => $schema,
             user  => TestUser->new($roles),
+            req   => TestRequest->new({}),
+            response => TestResponse->new,
         }, $class;
     }
 
@@ -95,6 +124,15 @@ use Bracket::Service::BracketStructure;
 
     sub go_to { return $_[0]->{go_to}; }
     sub user { return $_[0]->{user}; }
+    sub req { return $_[0]->{req}; }
+    sub request { return $_[0]->{req}; }
+    sub response { return $_[0]->{response}; }
+    sub flash { return $_[0]->{flash}; }
+    sub controller { my ($self, $name) = @_; return TestControllerRef->new($name); }
+    sub uri_for {
+        my ($self, @parts) = @_;
+        return join('/', map { ref($_) && $_->can('name') ? $_->name : $_ } @parts);
+    }
 }
 
 my $schema = BracketTestSchema->init_schema(populate => 1);
@@ -157,5 +195,50 @@ is($report_rows->[0]->{player_id}, 2, 'incomplete player id is reported');
 is($report_rows->[0]->{total_picks}, 10, 'total picks count is reported');
 is($report_rows->[0]->{missing_total}, 53, 'missing pick count is reported');
 is($report_rows->[0]->{final4_picks}, 0, 'final4 picks count is reported');
+
+# update_points surfaces timing stats and redirects back to leaderboard
+$controller->update_points($admin);
+like($admin->flash->{status_msg}, qr/equity_cache:/, 'update_points flash includes equity cache timing');
+is($admin->response->redirect_to, 'all', 'update_points redirects to leaderboard');
+
+# equity_report reuses cached default projection only for default cache params
+my $cached_projection = {
+    player_projections => [
+        { player_id => 2, projected_first_pct => '12.34', projected_podium_pct => '56.78', max_possible_points => 123, projected_score_avg => '88.88' },
+    ],
+    source => 'cache',
+};
+my $live_projection = {
+    player_projections => [
+        { player_id => 2, projected_first_pct => '98.76', projected_podium_pct => '54.32', max_possible_points => 321, projected_score_avg => '77.77' },
+    ],
+    source => 'live',
+};
+my ($cache_calls, $project_calls) = (0, 0);
+
+{
+    no warnings 'redefine';
+    local *Bracket::Service::EquityProjection::load_default_cache = sub {
+        my ($class, $schema_arg) = @_;
+        $cache_calls++;
+        return $cached_projection;
+    };
+    local *Bracket::Service::EquityProjection::project = sub {
+        my ($class, $schema_arg, $opts) = @_;
+        $project_calls++;
+        return $live_projection;
+    };
+
+    $admin->{req} = TestRequest->new({ iterations => 2000, seed => 17 });
+    $controller->equity_report($admin);
+    is($admin->stash->{projection}, $cached_projection, 'equity_report uses cached projection for leaderboard-default params');
+    is($cache_calls, 1, 'cached projection loader called once for default-cache params');
+    is($project_calls, 0, 'live projection skipped when default cache is available');
+
+    $admin->{req} = TestRequest->new({ iterations => 4000, seed => 17 });
+    $controller->equity_report($admin);
+    is($admin->stash->{projection}, $live_projection, 'equity_report keeps live projection for non-cached params');
+    is($project_calls, 1, 'live projection called for non-cached params');
+}
 
 done_testing();

--- a/t/equity_cache.t
+++ b/t/equity_cache.t
@@ -106,4 +106,46 @@ my $after_update = Bracket::Service::EquityProjection->load_default_cache($schem
 ok(defined $after_update, '_update_points_for_schema refreshes the equity cache');
 ok(exists $after_update->{player_projections}, 'cache populated by update_points has player_projections');
 
+# ── Test 5: MySQL update_points path also refreshes the cache ─────────────────
+
+{
+    package Local::TestDBH;
+    sub new { bless { Driver => { Name => 'mysql' } }, shift }
+
+    package Local::TestStorage;
+    sub new { bless { dbh => Local::TestDBH->new }, shift }
+    sub dbh { shift->{dbh} }
+
+    package Local::TestSchema;
+    sub new { bless { storage => Local::TestStorage->new }, shift }
+    sub storage { shift->{storage} }
+}
+
+my $fake_schema = Local::TestSchema->new;
+my $mysql_path_called = 0;
+my $cache_refresh_called = 0;
+my $cache_refresh_schema;
+
+{
+    no warnings 'redefine';
+    local *Bracket::Model::DBIC::_update_points_mysql = sub {
+        my ($schema_arg) = @_;
+        $mysql_path_called++;
+        return 'mysql stats';
+    };
+    local *Bracket::Service::EquityProjection::refresh_default_cache = sub {
+        my ($class, $schema_arg) = @_;
+        $cache_refresh_called++;
+        $cache_refresh_schema = $schema_arg;
+        return;
+    };
+
+    my $stats = Bracket::Model::DBIC::_update_points_for_schema($fake_schema);
+    is($stats, 'mysql stats', 'mysql path returns raw update_points stats');
+}
+
+is($mysql_path_called, 1, 'mysql update_points path invoked exactly once');
+is($cache_refresh_called, 1, 'mysql update_points path refreshes equity cache');
+is($cache_refresh_schema, $fake_schema, 'mysql cache refresh receives same schema object');
+
 done_testing();

--- a/t/equity_cache.t
+++ b/t/equity_cache.t
@@ -1,0 +1,109 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib qw(t/lib lib);
+use BracketTestSchema;
+use Bracket::Service::EquityProjection;
+use Bracket::Model::DBIC;
+
+my $schema = BracketTestSchema->init_schema(populate => 1);
+
+# ── Arrange: two active pool players with picks ───────────────────────────────
+
+$schema->resultset('Player')->search({ id => { '!=' => 1 } })->update({ active => 0 });
+
+my $player_a = $schema->resultset('Player')->create({
+    username   => 'cache_tester_a',
+    password   => 'test',
+    first_name => 'Cache',
+    last_name  => 'Alpha',
+    email      => 'cache_a@example.test',
+    active     => 1,
+    points     => 0,
+});
+my $player_b = $schema->resultset('Player')->create({
+    username   => 'cache_tester_b',
+    password   => 'test',
+    first_name => 'Cache',
+    last_name  => 'Beta',
+    email      => 'cache_b@example.test',
+    active     => 1,
+    points     => 0,
+});
+
+# Give both players picks on a couple of games
+$schema->resultset('Pick')->delete;
+for my $row (
+    [$player_a->id, 1, 1],
+    [$player_a->id, 2, 3],
+    [$player_b->id, 1, 1],
+    [$player_b->id, 2, 4],
+) {
+    $schema->resultset('Pick')->create({ player => $row->[0], game => $row->[1], pick => $row->[2] });
+}
+
+# ── Test 1: fresh schema has no cached projection ─────────────────────────────
+
+my $empty = Bracket::Service::EquityProjection->load_default_cache($schema);
+is($empty, undef, 'load_default_cache returns undef when equity_cache is empty');
+
+# ── Test 2: refresh_default_cache populates the cache ─────────────────────────
+
+Bracket::Service::EquityProjection->refresh_default_cache($schema);
+
+my $cache = Bracket::Service::EquityProjection->load_default_cache($schema);
+ok(defined $cache, 'load_default_cache returns data after refresh_default_cache');
+ok(ref($cache) eq 'HASH', 'cached result is a hash');
+ok(exists $cache->{player_projections}, 'cached result has player_projections key');
+
+my @projections = @{ $cache->{player_projections} || [] };
+ok(@projections >= 2, 'cache contains at least two player projection rows');
+
+my %by_player = map { $_->{player_id} => $_ } @projections;
+ok(exists $by_player{$player_a->id}, 'player A has a cached projection row');
+ok(exists $by_player{$player_b->id}, 'player B has a cached projection row');
+
+my $row_a = $by_player{$player_a->id};
+like($row_a->{projected_first_pct},  qr/^\d+\.\d+$/, 'projected_first_pct looks numeric');
+like($row_a->{projected_podium_pct}, qr/^\d+\.\d+$/, 'projected_podium_pct looks numeric');
+like($row_a->{projected_score_avg},  qr/^\d+\.\d+$/, 'projected_score_avg looks numeric');
+ok(defined $row_a->{max_possible_points}, 'max_possible_points is present');
+
+# ── Test 3: refresh overwrites stale cache ─────────────────────────────────────
+
+# Manually insert a sentinel row, then refresh and verify it's gone
+$schema->resultset('EquityCache')->update_or_create({
+    player_id            => $player_a->id,
+    cache_key            => 'default',
+    current_points       => 9999,
+    max_possible_points  => 9999,
+    projected_first_pct  => '99.00',
+    projected_podium_pct => '99.00',
+    projected_score_avg  => '999.00',
+});
+
+Bracket::Service::EquityProjection->refresh_default_cache($schema);
+
+my $after = Bracket::Service::EquityProjection->load_default_cache($schema);
+my %after_by_player = map { $_->{player_id} => $_ } @{ $after->{player_projections} || [] };
+isnt($after_by_player{$player_a->id}{current_points}, 9999,
+    'refresh_default_cache replaces stale cache rows');
+
+# ── Test 4: _update_points_for_schema also refreshes the cache ───────────────
+
+$schema->resultset('EquityCache')->delete;
+is(Bracket::Service::EquityProjection->load_default_cache($schema), undef,
+    'cache is empty before update_points');
+
+# Give perfect-bracket player a pick so update_points has something to do
+$schema->resultset('Pick')->search({ player => 1 })->delete;
+$schema->resultset('Pick')->create({ player => 1, game => 9, pick => 1 });
+
+Bracket::Model::DBIC::_update_points_for_schema($schema);
+
+my $after_update = Bracket::Service::EquityProjection->load_default_cache($schema);
+ok(defined $after_update, '_update_points_for_schema refreshes the equity cache');
+ok(exists $after_update->{player_projections}, 'cache populated by update_points has player_projections');
+
+done_testing();

--- a/t/equity_cache.t
+++ b/t/equity_cache.t
@@ -141,7 +141,7 @@ my $cache_refresh_schema;
     };
 
     my $stats = Bracket::Model::DBIC::_update_points_for_schema($fake_schema);
-    is($stats, 'mysql stats', 'mysql path returns raw update_points stats');
+    like($stats, qr/^mysql stats(?:<br>)?equity_cache: 0\.0$/, 'mysql path appends equity cache timing to update_points stats');
 }
 
 is($mysql_path_called, 1, 'mysql update_points path invoked exactly once');

--- a/t/model_update_points.t
+++ b/t/model_update_points.t
@@ -45,6 +45,7 @@ set_pick($player->id, 9, 2);
 
 my $stats = Bracket::Model::DBIC::_update_points_for_schema($schema);
 like($stats, qr/total time:/, 'update_points reports execution stats');
+like($stats, qr/equity_cache:/, 'update_points stats include equity cache refresh time');
 
 my $game1 = $schema->resultset('Game')->find(1);
 my $game2 = $schema->resultset('Game')->find(2);


### PR DESCRIPTION
## Summary
- cache the default equity projection in the database to speed up `/all`
- refresh the cache after `update_points` for both MySQL and portable paths
- reuse the cached default only when `/equity_report` explicitly requests the cached default params (`iterations=2000`, `seed=17`)
- include equity cache refresh time in `update_points` status output

## Details
This keeps `/all` fast after score updates by moving the expensive equity computation into the admin update flow instead of recalculating it on each leaderboard request.

The default `/equity_report` behavior remains live and unchanged. Only explicit requests matching the cached leaderboard-default run reuse cached data.

## Testing
- `script/test-env.sh prove -qlr t`
- locally verified `/all` loads quickly on the branch
